### PR TITLE
Add bilig-workpaper skill

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,8 +1,8 @@
 # Skill Catalog
 
-Generated at: 2026-04-26T06:19:25.360Z
+Generated at: 2026-05-18T15:12:05.764Z
 
-Total skills: 793
+Total skills: 794
 
 ## architecture (64)
 
@@ -116,7 +116,7 @@ Total skills: 793
 | `startup-financial-modeling` | This skill should be used when the user asks to "create financial projections", "build a financial model", "forecast revenue", "calculate burn rate", "estima... | startup, financial, modeling | startup, financial, modeling, skill, should, used, user, asks, projections, model, forecast, revenue |
 | `team-composition-analysis` | This skill should be used when the user asks to "plan team structure", "determine hiring needs", "design org chart", "calculate compensation", "plan equity a... | team, composition | team, composition, analysis, skill, should, used, user, asks, plan, structure, determine, hiring |
 
-## data-ai (178)
+## data-ai (179)
 
 | Skill | Description | Tags | Triggers |
 | --- | --- | --- | --- |
@@ -142,6 +142,7 @@ Total skills: 793
 | `behavioral-modes` | AI operational modes (brainstorm, implement, debug, review, teach, ship, orchestrate). Use to adapt behavior based on task type. | behavioral, modes | behavioral, modes, ai, operational, brainstorm, debug, review, teach, ship, orchestrate, adapt, behavior |
 | `benchling-integration` | Benchling R&D platform integration. Access registry (DNA, proteins), inventory, ELN entries, workflows via API, build Benchling Apps, query Data Warehouse, f... | benchling, integration | benchling, integration, platform, access, registry, dna, proteins, inventory, eln, entries, via, api |
 | `bgpt-paper-search` | Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper inc... | bgpt, paper, search | bgpt, paper, search, scientific, papers, retrieve, structured, experimental, data, extracted, full, text |
+| `bilig-workpaper` | Formula WorkPaper runtime and MCP server for AI agents and Node.js services. Use when an agent needs spreadsheet-style formulas, cell edits, recalculation, r... | bilig, workpaper | bilig, workpaper, formula, runtime, mcp, server, ai, agents, node, js, agent, spreadsheet |
 | `biorxiv-database` | Efficient database search tool for bioRxiv preprint server. Use this skill when searching for life sciences preprints by keywords, authors, date ranges, or c... | biorxiv, database | biorxiv, database, efficient, search, preprint, server, skill, searching, life, sciences, preprints, keywords |
 | `bioservices` | Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with con... | bioservices | bioservices, unified, python, interface, 40, bioinformatics, querying, multiple, databases, uniprot, kegg, chembl |
 | `blockrun` | Use when user needs capabilities Claude lacks (image generation, real-time X/Twitter data) or explicitly requests external models ("blockrun", "use grok", "u... | blockrun | blockrun, user, capabilities, claude, lacks, image, generation, real, time, twitter, data, explicitly |

--- a/data/aliases.json
+++ b/data/aliases.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-26T06:19:25.360Z",
+  "generatedAt": "2026-05-18T15:12:05.764Z",
   "aliases": {
     "accessibility-compliance-audit": "accessibility-compliance-accessibility-audit",
     "active directory attacks": "active-directory-attacks",

--- a/data/bundles.json
+++ b/data/bundles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-26T06:19:25.360Z",
+  "generatedAt": "2026-05-18T15:12:05.764Z",
   "bundles": {
     "core-dev": {
       "description": "Core development skills across languages, frameworks, and backend/frontend fundamentals.",
@@ -28,6 +28,7 @@
         "backend-development-feature-development",
         "backend-security-coder",
         "benchling-integration",
+        "bilig-workpaper",
         "bioservices",
         "brenda-database",
         "bullmq-specialist",

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-26T06:19:25.360Z",
-  "total": 793,
+  "generatedAt": "2026-05-18T15:12:05.764Z",
+  "total": 794,
   "skills": [
     {
       "id": "3d-web-experience",
@@ -1940,6 +1940,31 @@
         "text"
       ],
       "path": "skills/bgpt-paper-search/SKILL.md"
+    },
+    {
+      "id": "bilig-workpaper",
+      "name": "bilig-workpaper",
+      "description": "Formula WorkPaper runtime and MCP server for AI agents and Node.js services. Use when an agent needs spreadsheet-style formulas, cell edits, recalculation, readback verification, or persisted WorkPaper JSON without driving Excel UI.",
+      "category": "data-ai",
+      "tags": [
+        "bilig",
+        "workpaper"
+      ],
+      "triggers": [
+        "bilig",
+        "workpaper",
+        "formula",
+        "runtime",
+        "mcp",
+        "server",
+        "ai",
+        "agents",
+        "node",
+        "js",
+        "agent",
+        "spreadsheet"
+      ],
+      "path": "skills/bilig-workpaper/SKILL.md"
     },
     {
       "id": "billing-automation",

--- a/skills/bilig-workpaper/SKILL.md
+++ b/skills/bilig-workpaper/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: bilig-workpaper
+description: Formula WorkPaper runtime and MCP server for AI agents and Node.js services. Use when an agent needs spreadsheet-style formulas, cell edits, recalculation, readback verification, or persisted WorkPaper JSON without driving Excel UI.
+risk: safe
+source: proompteng/bilig (MIT)
+---
+
+# Bilig WorkPaper
+
+## Overview
+
+Bilig WorkPaper gives agents a reviewable spreadsheet model without requiring browser or Excel UI automation. Use it to edit cells through an API, recalculate formulas, verify display-value readback, and persist WorkPaper JSON for audit or restore flows.
+
+## When to Use This Skill
+
+- Use when an agent needs spreadsheet-style formulas in a backend service or local workflow.
+- Use when the task involves editing input cells, recalculating formulas, and proving the output with readback.
+- Use when Excel, Google Sheets, or screenshot-driven spreadsheet automation would be too brittle.
+- Use when a workflow needs file-backed WorkPaper JSON that can be reviewed, restored, or versioned.
+
+## Step-by-Step Guide
+
+### 1. Install or run the package
+
+Use the package directly with npm exec when you only need the MCP server:
+
+```bash
+npm exec --package @bilig/headless -- bilig-workpaper-mcp --workpaper ./pricing.workpaper.json --init-demo-workpaper --writable
+```
+
+For TypeScript code, install the package in the project:
+
+```bash
+npm install @bilig/headless
+```
+
+### 2. Prefer WorkPaper state over UI automation
+
+Keep workbook state in a WorkPaper JSON document. Write inputs through the WorkPaper API or MCP tools, recalculate, then read the computed display value back from the model.
+
+### 3. Use the MCP tools for agent workflows
+
+A file-backed MCP session should expose tools for listing sheets, reading cells or ranges, setting cell contents, validating formulas, exporting the document, and reading display values after recalculation.
+
+### 4. Verify after every mutation
+
+After each write, read the changed input cell and the dependent output cell. Keep the exported WorkPaper JSON when the task needs proof, rollback, or a reproducible bug report.
+
+## Examples
+
+### Example 1: File-backed MCP server
+
+```bash
+npm exec --package @bilig/headless -- bilig-workpaper-mcp --workpaper ./pricing.workpaper.json --init-demo-workpaper --writable
+```
+
+An agent can then update `Inputs!B3`, read `Summary!B3`, and export the updated WorkPaper JSON.
+
+### Example 2: TypeScript service workflow
+
+```ts
+import { WorkPaper } from "@bilig/headless";
+
+const paper = new WorkPaper();
+paper.setCellContents("Inputs", "B2", 1200);
+paper.setCellContents("Inputs", "B3", "=B2*1.2");
+paper.recalculate();
+
+const result = paper.getCellDisplayValue("Inputs", "B3");
+console.log(result);
+```
+
+## Best Practices
+
+- Do use Bilig for formulas, readback, and persisted spreadsheet state when the workflow can live outside Excel UI.
+- Do keep formula inputs, computed outputs, and exported WorkPaper JSON together when reporting bugs or validating agent changes.
+- Do validate formulas before writing them into cells when the agent is generating formulas.
+- Don't use screenshot or browser automation for spreadsheet logic if a WorkPaper API call can express the same operation directly.
+- Don't treat a write as complete until a readback proves the computed output changed as expected.
+
+## Troubleshooting
+
+**Problem:** The agent wrote a formula but the output did not change.  
+**Solution:** Recalculate the WorkPaper, then read both the input cell and the dependent display-value cell.
+
+**Problem:** The workflow needs to preserve state across agent turns.  
+**Solution:** Run the MCP server with `--workpaper ./file.workpaper.json --writable` and export the document after important changes.

--- a/skills_index.json
+++ b/skills_index.json
@@ -720,6 +720,15 @@
     "source": "unknown"
   },
   {
+    "id": "bilig-workpaper",
+    "path": "skills/bilig-workpaper",
+    "category": "uncategorized",
+    "name": "bilig-workpaper",
+    "description": "Formula WorkPaper runtime and MCP server for AI agents and Node.js services. Use when an agent needs spreadsheet-style formulas, cell edits, recalculation, readback verification, or persisted WorkPaper JSON without driving Excel UI.",
+    "risk": "safe",
+    "source": "proompteng/bilig (MIT)"
+  },
+  {
     "id": "billing-automation",
     "path": "skills/billing-automation",
     "category": "uncategorized",


### PR DESCRIPTION
## Summary
Add `bilig-workpaper`, a skill for using Bilig WorkPaper as a formula-backed spreadsheet runtime and MCP server for agents.

The skill focuses on direct cell edits, formula recalculation, display-value readback, and persisted WorkPaper JSON instead of brittle Excel/browser UI automation.

## Validation
- `python3 scripts/validate_skills.py`
- `python3 scripts/generate_index.py`
- `python3 scripts/update_readme.py`
- `npm run catalog`
- `npm run test`