### PR TITLE
feat: add infolobby skill

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,8 +1,8 @@
 # Skill Catalog
 
-Generated at: 2026-05-20T06:48:40.204Z
+Generated at: 2026-06-05T12:30:58.545Z
 
-Total skills: 794
+Total skills: 795
 
 ## architecture (64)
 
@@ -116,7 +116,7 @@ Total skills: 794
 | `startup-financial-modeling` | This skill should be used when the user asks to "create financial projections", "build a financial model", "forecast revenue", "calculate burn rate", "estima... | startup, financial, modeling | startup, financial, modeling, skill, should, used, user, asks, projections, model, forecast, revenue |
 | `team-composition-analysis` | This skill should be used when the user asks to "plan team structure", "determine hiring needs", "design org chart", "calculate compensation", "plan equity a... | team, composition | team, composition, analysis, skill, should, used, user, asks, plan, structure, determine, hiring |
 
-## data-ai (179)
+## data-ai (180)
 
 | Skill | Description | Tags | Triggers |
 | --- | --- | --- | --- |
@@ -212,6 +212,7 @@ Total skills: 794
 | `hypothesis-generation` | Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predi... | hypothesis, generation | hypothesis, generation, structured, formulation, observations, experimental, data, formulate, testable, hypotheses, predictions, propose |
 | `imaging-data-commons` | Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathol... | imaging, data, commons | imaging, data, commons, query, download, public, cancer, nci, idc, index, accessing, large |
 | `infographics` | Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup a... | infographics | infographics, professional, nano, banana, pro, ai, smart, iterative, refinement, uses, gemini, quality |
+| `infolobby` | Use when the user wants to read, query, or modify their InfoLobby workspace data — list spaces and tables, get a table schema, create/update/delete/query rec... | infolobby | infolobby, user, wants, read, query, modify, workspace, data, list, spaces, tables, get |
 | `ios-developer` | Develop native iOS applications with Swift/SwiftUI. Masters iOS 18, SwiftUI, UIKit integration, Core Data, networking, and App Store optimization. Use PROACT... | ios | ios, developer, develop, native, applications, swift, swiftui, masters, 18, uikit, integration, core |
 | `kegg-database` | Direct REST API access to KEGG (academic use only). Pathway analysis, gene-pathway mapping, metabolic pathways, drug interactions, ID conversion. For Python ... | kegg, database | kegg, database, direct, rest, api, access, academic, pathway, analysis, gene, mapping, metabolic |
 | `langchain-architecture` | Design LLM applications using the LangChain framework with agents, memory, and tool integration patterns. Use when building LangChain applications, implement... | langchain, architecture | langchain, architecture, llm, applications, framework, agents, memory, integration, building, implementing, ai, creating |

--- a/data/aliases.json
+++ b/data/aliases.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
+  "generatedAt": "2026-06-05T12:30:58.545Z",
   "aliases": {
     "accessibility-compliance-audit": "accessibility-compliance-accessibility-audit",
     "active directory attacks": "active-directory-attacks",

--- a/data/bundles.json
+++ b/data/bundles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
+  "generatedAt": "2026-06-05T12:30:58.545Z",
   "bundles": {
     "core-dev": {
       "description": "Core development skills across languages, frameworks, and backend/frontend fundamentals.",
@@ -84,6 +84,7 @@
         "hedgefundmonitor",
         "hubspot-integration",
         "hugging-face-jobs",
+        "infolobby",
         "ios-developer",
         "java-pro",
         "javascript-mastery",
@@ -401,6 +402,7 @@
         "idor-testing",
         "imaging-data-commons",
         "infographics",
+        "infolobby",
         "ios-developer",
         "kegg-database",
         "kpi-dashboard-design",

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
-  "total": 794,
+  "generatedAt": "2026-06-05T12:30:58.545Z",
+  "total": 795,
   "skills": [
     {
       "id": "3d-web-experience",
@@ -9218,6 +9218,30 @@
         "quality"
       ],
       "path": "skills/infographics/SKILL.md"
+    },
+    {
+      "id": "infolobby",
+      "name": "infolobby",
+      "description": "Use when the user wants to read, query, or modify their InfoLobby workspace data — list spaces and tables, get a table schema, create/update/delete/query records, post comments, or upload/download record attachments. Requires the user's InfoLobby API key, which the skill prompts for once and caches at ~/.infolobby/key.",
+      "category": "data-ai",
+      "tags": [
+        "infolobby"
+      ],
+      "triggers": [
+        "infolobby",
+        "user",
+        "wants",
+        "read",
+        "query",
+        "modify",
+        "workspace",
+        "data",
+        "list",
+        "spaces",
+        "tables",
+        "get"
+      ],
+      "path": "skills/infolobby/SKILL.md"
     },
     {
       "id": "inngest",

--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -296,6 +296,25 @@ function renderCatalogMarkdown(catalog) {
   return lines.join('\n');
 }
 
+function readExistingCatalog(catalogPath) {
+  try {
+    return JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+  } catch (_) {
+    return null;
+  }
+}
+
+function sameCatalogContent(existing, next) {
+  if (!existing) return false;
+  return JSON.stringify({
+    total: existing.total,
+    skills: existing.skills,
+  }) === JSON.stringify({
+    total: next.total,
+    skills: next.skills,
+  });
+}
+
 function buildCatalog() {
   const skillRelPaths = listSkillIdsRecursive(SKILLS_DIR);
   const skills = skillRelPaths.map(relPath => readSkill(SKILLS_DIR, relPath));
@@ -317,19 +336,23 @@ function buildCatalog() {
     });
   }
 
-  const catalog = {
-    generatedAt: new Date().toISOString(),
-    total: catalogSkills.length,
-    skills: catalogSkills.sort((a, b) => a.id.localeCompare(b.id)),
-  };
-
-  const aliases = buildAliases(catalog.skills);
-  const bundleData = buildBundles(catalog.skills);
-
   const catalogPath = path.join(ROOT, 'data', 'catalog.json');
   const catalogMarkdownPath = path.join(ROOT, 'CATALOG.md');
   const bundlesPath = path.join(ROOT, 'data', 'bundles.json');
   const aliasesPath = path.join(ROOT, 'data', 'aliases.json');
+
+  const catalog = {
+    generatedAt: '',
+    total: catalogSkills.length,
+    skills: catalogSkills.sort((a, b) => a.id.localeCompare(b.id)),
+  };
+  const existingCatalog = readExistingCatalog(catalogPath);
+  catalog.generatedAt = sameCatalogContent(existingCatalog, catalog)
+    ? existingCatalog.generatedAt
+    : new Date().toISOString();
+
+  const aliases = buildAliases(catalog.skills);
+  const bundleData = buildBundles(catalog.skills);
 
   fs.writeFileSync(catalogPath, JSON.stringify(catalog, null, 2));
   fs.writeFileSync(catalogMarkdownPath, renderCatalogMarkdown(catalog));

--- a/skills/infolobby/SKILL.md
+++ b/skills/infolobby/SKILL.md
@@ -2,14 +2,19 @@
 name: infolobby
 description: Use when the user wants to read, query, or modify their InfoLobby workspace data — list spaces and tables, get a table schema, create/update/delete/query records, post comments, or upload/download record attachments. Requires the user's InfoLobby API key, which the skill prompts for once and caches at ~/.infolobby/key.
 license: MIT
+risk: safe
+source: https://infolobby.com/skill
 metadata:
-  source: https://infolobby.com/skill
   vendor: Globi Web Solutions
 ---
 
 # InfoLobby
 
 Access an InfoLobby account from any agent using plain `curl`. No SDK.
+
+## When to Use
+
+Use for InfoLobby data operations: discover spaces/tables, inspect schemas, query records, mutate records, comments, and record attachments.
 
 ## Setup
 

--- a/skills/infolobby/SKILL.md
+++ b/skills/infolobby/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: infolobby
+description: Use when the user wants to read, query, or modify their InfoLobby workspace data — list spaces and tables, get a table schema, create/update/delete/query records, post comments, or upload/download record attachments. Requires the user's InfoLobby API key, which the skill prompts for once and caches at ~/.infolobby/key.
+license: MIT
+metadata:
+  source: https://infolobby.com/skill
+  vendor: Globi Web Solutions
+---
+
+# InfoLobby
+
+Access an InfoLobby account from any agent using plain `curl`. No SDK.
+
+## Setup
+
+The API key lives at `~/.infolobby/key` (one line, the raw token).
+
+**On every invocation**, first try to read it:
+
+```bash
+INFOLOBBY_KEY="$(cat ~/.infolobby/key 2>/dev/null)"
+INFOLOBBY_API="https://infolobby.com/api"
+```
+
+If `~/.infolobby/key` does not exist, ask the user once for their InfoLobby API key (`il_live_…` or `il_user_…`), then write it. Do not log or echo the key back.
+
+- macOS / Linux:
+  ```bash
+  mkdir -p ~/.infolobby
+  ( umask 077 && printf '%s' "<KEY>" > ~/.infolobby/key )
+  ```
+- Windows (PowerShell):
+  ```powershell
+  New-Item -ItemType Directory -Force "$HOME\.infolobby" | Out-Null
+  Set-Content -NoNewline "$HOME\.infolobby\key" '<KEY>'
+  ```
+
+Where the user gets a key:
+
+- **Account key** (`il_live_…`): InfoLobby → **Account → API Keys**. Account-owner only. Acts as the owner across all in-scope workspaces.
+- **Personal key** (`il_user_…`): InfoLobby → **Profile → Personal API Keys**. Acts as that user; cannot manage workspaces or table schemas.
+
+Send the key on every request as `Authorization: Bearer $INFOLOBBY_KEY`.
+
+## Scope
+
+This skill covers data work only:
+
+- discover: list spaces, list tables, fetch a table schema
+- records: create, get, update, delete, batch-delete, **query with filters / saved views**
+- comments: list, post, attach files
+- files: upload, download, delete record attachments (base64 in JSON, 50 MB cap)
+
+This skill does **not** create/modify workspaces, create/modify table schemas, manage members, run flows, or touch billing. Point the user at [https://infolobby.com/api-docs](https://infolobby.com/api-docs) for those.
+
+## Workflow
+
+Always discover before mutating:
+
+1. `GET /spaces/list` → pick a space.
+2. `GET /space/<space_id>/tables/list` → pick a table.
+3. `GET /table/<table_id>/get` → read field `id` slugs from the schema. Record payloads use these slugs, **not** display names — a wrong key returns `Unauthorized - no field edit permissions for field: X`.
+
+## Cheat sheet
+
+| Action | Verb | Path |
+|---|---|---|
+| List spaces | GET | `/spaces/list` |
+| List tables | GET | `/space/<sid>/tables/list` |
+| Get table schema | GET | `/table/<tid>/get` |
+| List views | GET | `/table/<tid>/views/list` |
+| Query records | POST | `/table/<tid>/records/query` |
+| Get record | GET | `/table/<tid>/record/<rid>/get` |
+| Create record | POST | `/table/<tid>/records/create` |
+| Update record | POST | `/table/<tid>/record/<rid>/update` |
+| Delete record | POST | `/table/<tid>/record/<rid>/delete` |
+| List comments | GET | `/table/<tid>/record/<rid>/comments/get?limit=20` |
+| Add comment | POST | `/table/<tid>/record/<rid>/comments/create` |
+| Upload attachment | POST | `/table/<tid>/record/<rid>/files/create` |
+| Download attachment | POST | `/table/<tid>/record/<rid>/files/get` |
+| Delete attachment | POST | `/table/<tid>/record/<rid>/files/delete` |
+
+## Query example
+
+```bash
+curl -s "$INFOLOBBY_API/table/101/records/query" \
+  -H "Authorization: Bearer $INFOLOBBY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fields": ["company_name","email","status"],
+    "filters": [{"column":"status","compare":"=","value":"Active"}],
+    "order_by": "company_name",
+    "order_dir": "A",
+    "limit": 50
+  }'
+```
+
+Pass `"view_id": N` to query through a saved view; the view's filters and sort replace the request's.
+
+## Create / update record example
+
+```bash
+curl -s -X POST "$INFOLOBBY_API/table/101/records/create" \
+  -H "Authorization: Bearer $INFOLOBBY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"data":{"company_name":"Acme","email":"hello@acme.test","status":"Active"}}'
+```
+
+`data` keys must be field `id` slugs from `GET /table/<tid>/get`. Update bodies are partial — include only fields to change.
+
+## Files (base64)
+
+```bash
+B64=$(base64 -w0 invoice.pdf)
+curl -s -X POST "$INFOLOBBY_API/table/101/record/5/files/create" \
+  -H "Authorization: Bearer $INFOLOBBY_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"field_id\":\"attachments\",\"name\":\"invoice.pdf\",\"type\":\"application/pdf\",\"data\":\"$B64\"}"
+```
+
+Decoded payload must be ≤ 50 MB. Download returns base64 in `data`. Attachment object shape on the record is `{name,path,type,size,host}`. `files/delete` strips by `(field_id, path)`.
+
+## Error handling
+
+- Non-2xx → plain text body.
+- `401` → key missing/invalid/revoked; reprompt and rewrite `~/.infolobby/key`.
+- `403` → read-only key on a write call, or endpoint not in scope for the key type.
+- `429` → respect `Retry-After`. `X-RateLimit-*` headers describe the bucket.
+- `500` with `Unauthorized - no field edit permissions for field: X` → field slug is wrong; refetch schema.
+
+## References
+
+- [references/endpoints.md](references/endpoints.md) — full endpoint list and request bodies for the in-scope surface.
+- [references/fields.md](references/fields.md) — field-type quirks that surprise first-time callers (lookup, select, user, number, date).
+
+## Tips
+
+- Base URL: `https://infolobby.com/api`.
+- Responses are JSON for data endpoints; errors are plain text with non-2xx status.
+- Use `curl -i` when debugging auth or scoping issues.
+- Personal keys (`il_user_…`) cannot CRUD workspaces or table schemas — that is by design.
+- Never write the user's key into chat output, command history echoes, or logs.

--- a/skills/infolobby/references/endpoints.md
+++ b/skills/infolobby/references/endpoints.md
@@ -1,0 +1,98 @@
+# InfoLobby endpoints — public skill scope
+
+Base URL: `https://infolobby.com/api`
+
+Send `Authorization: Bearer <key>` on every request.
+
+## Discovery
+
+- `GET /spaces/list` — list spaces the key can see.
+- `GET /space/<space_id>/get` — one space's metadata.
+- `GET /space/<space_id>/tables/list` — tables in a space.
+- `GET /table/<table_id>/get` — full table metadata + field schema. Use this to get field `id` slugs before any record write.
+- `GET /table/<table_id>/views/list` — saved views (includes synthetic Default view id `0`).
+- `GET /table/<table_id>/view/<view_id>/get` — one view's filters and sort.
+
+## Records
+
+Field write rules (see also `fields.md`):
+
+- Keys in `data` are field `id` slugs from the schema, not display labels.
+- Update is partial — send only fields to change.
+- Empty `{"data":{}}` returns `Unknown column '' in 'field list'`.
+
+| Verb | Path | Body |
+|---|---|---|
+| POST | `/table/<tid>/records/create` | `{"data":{...}}` |
+| GET | `/table/<tid>/record/<rid>/get` | — |
+| POST | `/table/<tid>/record/<rid>/update` | `{"data":{...}}` |
+| POST | `/table/<tid>/record/<rid>/delete` | — |
+| POST | `/table/<tid>/records/delete_batch` | `{"record_ids":[...]}` |
+| POST | `/table/<tid>/records/query` | query body, see below |
+
+### Query body
+
+```json
+{
+  "fields": ["name","email"],
+  "where": {"status": "Active"},
+  "filters": [{"column": "age", "compare": ">", "value": 21}],
+  "order_by": "name",
+  "order_dir": "A",
+  "search": "acme",
+  "limit": 50,
+  "offset": 0,
+  "view_id": 0
+}
+```
+
+Compare operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, `starts_with`, `ends_with`, `is_empty`, `is_not_empty`. Aliases: `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `C`, `SW`, `EW`, `EMPTY`, `NEMPTY`.
+
+Date tokens (use inside filter `value`): `today`, `now`, `yesterday`, `start_of_week`, `start_of_month`, `start_of_year`, `start_of_last_week`, `start_of_last_month`, `start_of_last_year`, and relative offsets `-Nd`/`+Nd`/`-Nw`/`+Nw`/`-Nm`/`+Nm`/`-Ny`/`+Ny`.
+
+When `view_id` is set, the saved view's filters and sort **replace** the request's filters/sort. `search`, `limit`, `offset`, and `fields` still apply on top.
+
+### Response shapes
+
+`records/create`, `record/<rid>/get`, `record/<rid>/update` return `{"id","title","data":{…}}` with values nested under `data`. Select values come back as one-element arrays here: `"status":["Active"]`.
+
+`records/query` returns a **flat array** of objects with field ids at the top level — no `data` wrapper. Select values are scalars. Lookup values are stringified ids with a sibling `<field>.json` of the title.
+
+## Comments
+
+- `GET /table/<tid>/record/<rid>/comments/get?limit=20&offset=0`
+- `POST /table/<tid>/record/<rid>/comments/create` — body `{"content":"...", "attachments":[]}`
+- `POST /table/<tid>/record/<rid>/comments/upload` — body `{"name","type","data"}`, base64; returns attachment metadata to put into `attachments` of the next comment create
+
+Mentions inside `content` use `@{<user_id>:<display_name>}`. API-created comments show as `API: <key name>` in the UI.
+
+## Files
+
+JSON + base64 transport only (no multipart). 50 MB decoded cap.
+
+- `POST /table/<tid>/record/<rid>/files/create` — body `{"field_id","name","type?","data"}`. Appends to the named file field. Allowed for non-read-only keys with edit rights on the field.
+- `POST /table/<tid>/record/<rid>/files/delete` — body `{"field_id","path"}`. Strips the matching attachment from the field's array. Underlying storage is reclaimed by a nightly GC after a 30-day grace period (managed storage only).
+- `POST /table/<tid>/record/<rid>/files/get` — body `{"field_id","path"}`. Returns `data` as base64. Allowed for read-only keys.
+
+Attachment object stored on the record: `{name, path, type, size, host}`. The `path` is the tenant-prefixed S3 key; do not synthesise it — use the value returned by `create` or read from the record.
+
+## Auth & limits — quick reference
+
+- `il_live_` (account key): account rate bucket; can manage data across in-scope workspaces.
+- `il_user_` (personal key): user permissions; ¼ of the account's default rate; cannot manage workspaces or table schemas.
+- Read-only keys cannot write.
+- IP allowlist failures return 401.
+
+Rate-limit headers on every response: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Scope`. On 429, honour `Retry-After`.
+
+Error bodies are plain text. Status codes: 401 auth, 402 plan limit, 403 forbidden/scope, 429 rate limit, 500 application/validation, 503 API kill-switch.
+
+## Out of scope
+
+The following exist in the full public API but are intentionally **not** documented in this skill:
+
+- workspaces CRUD, table schema CRUD, members
+- subscriptions, standalone tasks, notifications, email
+- flows, webforms, integrations
+
+If the user needs any of those, point them at [https://infolobby.com/api-docs](https://infolobby.com/api-docs).

--- a/skills/infolobby/references/fields.md
+++ b/skills/infolobby/references/fields.md
@@ -1,0 +1,69 @@
+# InfoLobby field types — record-write quirks
+
+How values are written and read for each field type. Field metadata comes from `GET /table/<tid>/get`.
+
+Field `id` is the slug used in record payloads. The display label is in `name` — do **not** use it as a key.
+
+## Lookup
+
+A pointer to a record in another table.
+
+- **Write:** send the related record id as an integer. `"customer": 1`.
+- Also accepts `{id,title}` for editing-UI parity: `"customer": {"id": 1, "title": "Acme"}`. Only the `id` is stored.
+- **Read (`record/get`):** inflated to `{"id": 1, "title": "Acme"}`.
+- **Read (`records/query`):** scalar string id `"customer": "1"` with a sibling `"customer.json"` holding the title — query returns flat key/value rows.
+
+Target table is declared on the schema entry as `"table":{"id":<tid>,"text":"<Table Name>"}`. Skill code does not need to set this; only `create-table` flows do.
+
+## User
+
+A workspace member.
+
+- **Write:** the member's **email address**. `"agent": "admin@example.com"`.
+- Numeric `user_id` is rejected with `Invalid User N for Agent`, even when the value came back from `/space/<sid>/members/list`.
+- Object shapes (`{id,name}`, `{user_id}`) return an empty 200 body and silently fail to create a record — always check the response body is non-empty.
+
+## Number
+
+- Integer by default. `49.99` is truncated to `50`.
+- The field's `decimals` (in `options.decimals` on read; `decimals` at top level on schema write) controls precision.
+- With `decimals` set, accepts JSON numbers or numeric strings; preserved verbatim.
+
+## Select
+
+- **Write:** a single string. `"status": "Active"`.
+- **Read (`record/get`):** comes back as a one-element array `"status": ["Active"]`.
+- **Read (`records/query`):** scalar string.
+- Reading the schema, `options` is a normalized nested object — do not feed it back verbatim if reusing for create-table.
+
+## Date
+
+- **Write:** ISO date string `"YYYY-MM-DD"`.
+- **Filter values** can also use the date tokens listed in `endpoints.md` (`today`, `start_of_month`, `-7d`, etc.).
+
+## Key (auto-id)
+
+- One per table. Read-only on the API for records; the record id is auto-assigned.
+- `record/get` returns the int at the top level as well as `data.<key_field>` (often as string).
+
+## Calc
+
+- Read-only computed column. Writes return `Unassignable - cannot set calculation field: <id>` — omit from `data`.
+- Aggregate calcs over empty related sets return `null`. Compose with `IFNULL(...,0)` in formulas (formula authoring is out of skill scope).
+
+## File
+
+- A list of attachments. Manage through the `/files/*` endpoints — not by editing `data` directly.
+- Each attachment is `{name, path, type, size, host}`. `path` is server-assigned.
+- Replacing/reordering: use record update with the full attachment array.
+
+## Common write failures
+
+| Symptom | Cause |
+|---|---|
+| `Unauthorized - no field edit permissions for field: X` | Wrong field id slug. Refetch schema. |
+| `Unknown column '' in 'field list'` | Empty `data` object. |
+| `Unassignable - cannot set calculation field: X` | Wrote to a calc field. Drop it from `data`. |
+| `Invalid User N for Agent` | User field got an id instead of an email. |
+| empty 200 body on create | User field got an object shape; record was not created. |
+| values silently truncate decimals | Number field has no `decimals` set. |

--- a/skills_index.json
+++ b/skills_index.json
@@ -3330,6 +3330,15 @@
     "source": "unknown"
   },
   {
+    "id": "infolobby",
+    "path": "skills/infolobby",
+    "category": "uncategorized",
+    "name": "infolobby",
+    "description": "Use when the user wants to read, query, or modify their InfoLobby workspace data \u2014 list spaces and tables, get a table schema, create/update/delete/query records, post comments, or upload/download record attachments. Requires the user's InfoLobby API key, which the skill prompts for once and caches at ~/.infolobby/key.",
+    "risk": "safe",
+    "source": "https://infolobby.com/skill"
+  },
+  {
     "id": "inngest",
     "path": "skills/inngest",
     "category": "uncategorized",


### PR DESCRIPTION
Adds InfoLobby skill for working with InfoLobby workspace data through the public API.

Includes:
- SKILL.md
- references/endpoints.md
- references/fields.md

Validation note: validate:strict reports pre-existing catalog-wide issues unrelated to this PR; no errors observed for skills/infolobby.